### PR TITLE
Cmake edits

### DIFF
--- a/servers/CMakeLists.txt
+++ b/servers/CMakeLists.txt
@@ -23,7 +23,6 @@ add_subdirectory(sqllib)
 
 add_executable(Boxofhope boxofhope.cpp)
 
-
 # add the binary tree to the search path for include files
 # so that we will find TutorialConfig.h
 target_include_directories(Boxofhope PUBLIC
@@ -34,6 +33,22 @@ target_include_directories(Boxofhope PUBLIC
 find_package( Boost REQUIRED COMPONENTS system thread  )
 include_directories( ${Boost_INCLUDE_DIR} )
 
+# wiringPi only works on the RPi, therefore we must mock the library and it's functions if we are to compile on any other system
+
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+message( STATUS "Architecture: ${ARCHITECTURE}" )
+if( ${ARCHITECTURE} STREQUAL "aarch68" )
+    message( STATUS "Using wiringPi" )
+    find_package( wiringPi REQUIRED)
+else()
+    message( STATUS "Using wiringPi-mock" )
+    message( AUTHOR_WARNING "You are using the wiringPi-mock library. This means the program compiles as expected. However, any functionality from the original wiringPi library will not be usable." )
+    add_subdirectory( wiringPi-mock )
+    set( WIRINGPI_INCLUDE_DIRS "${PROJECT_BINARY_DIR}/wiringPi-mock" )
+    set( WIRINGPI_LIBRARIES "wiringPi" )
+endif()
+include_directories( ${WIRINGPI_INCLUDE_DIRS} )
+message( STATUS "wiringPi include location: ${WIRINGPI_INCLUDE_DIRS}" )
 
 # LINK THEM ALLLLLL
-target_link_libraries(Boxofhope PUBLIC io_server sqllib restful_server ${Boost_LIBRARIES} )
+target_link_libraries(Boxofhope PUBLIC io_server sqllib restful_server ${Boost_LIBRARIES} ${WIRINGPI_LIBRARIES})

--- a/servers/wiringPi-mock/CMakeLists.txt
+++ b/servers/wiringPi-mock/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(wiringPi)
+
+# add the library that runs
+set(wiringPi_source_files
+        wiringPi-mock.cpp
+)
+add_library(wiringPi ${wiringPi_source_files})
+
+# state that anybody linking to us needs to include the current source dir
+target_include_directories(wiringPi
+                           INTERFACE
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                            $<INSTALL_INTERFACE:include>
+                           )
+
+target_link_libraries(wiringPi PUBLIC)

--- a/servers/wiringPi-mock/version.h
+++ b/servers/wiringPi-mock/version.h
@@ -1,0 +1,3 @@
+#define VERSION "0.1"
+#define VERSION_MAJOR 0
+#define VERSION_MINOR 1

--- a/servers/wiringPi-mock/wiringPi-mock.cpp
+++ b/servers/wiringPi-mock/wiringPi-mock.cpp
@@ -1,0 +1,11 @@
+#include "wiringPi.h"
+#include "version.h"
+
+/** Copy wiringPi version function
+ * \return Major and minor version code via pointers
+ **/
+void wiringPiVersion (int *major, int *minor)
+{
+    *major = VERSION_MAJOR ;
+    *minor = VERSION_MINOR ;
+}

--- a/servers/wiringPi-mock/wiringPi-mock.cpp
+++ b/servers/wiringPi-mock/wiringPi-mock.cpp
@@ -1,9 +1,6 @@
 #include "wiringPi.h"
 #include "version.h"
 
-/** Copy wiringPi version function
- * \return Major and minor version code via pointers
- **/
 void wiringPiVersion (int *major, int *minor)
 {
     *major = VERSION_MAJOR ;

--- a/servers/wiringPi-mock/wiringPi.h
+++ b/servers/wiringPi-mock/wiringPi.h
@@ -1,0 +1,5 @@
+#ifndef WIRINGPI_MOCK
+#define WIRINGPI_MOCK
+
+void wiringPiVersion (int *major, int *minor);
+#endif

--- a/servers/wiringPi-mock/wiringPi.h
+++ b/servers/wiringPi-mock/wiringPi.h
@@ -1,5 +1,6 @@
 #ifndef WIRINGPI_MOCK
 #define WIRINGPI_MOCK
 
+/// Get the wiringPi version via pointers
 void wiringPiVersion (int *major, int *minor);
 #endif


### PR DESCRIPTION
### Problem

`wiringPi` only exists on Raspberry Pi and wouldn't compile or work on a normal system.

### Solution

Mock the `wiringPi` library and include it instead. However this would lead to reduced functionality. Maybe a control panel for managing events in the future could be created.